### PR TITLE
Update Group.cs

### DIFF
--- a/Toml/Group.cs
+++ b/Toml/Group.cs
@@ -197,15 +197,21 @@ namespace Toml
                 group = this;
                 return true;
             }
-
-            Group child = _children[keyParts.First()] as Group;
+            Group child;
+            if(_children.TryGetValue(keyParts.First(), out child))
+            {
+                return child.TryGetGroup(keyParts.Skip(1), out group);
+            }
+            group = null;
+            return false;
+            /*Group child = _children[keyParts.First()] as Group;
             if (child == null)
             {
                 group = null;
                 return false;
             }
 
-            return child.TryGetGroup(keyParts.Skip(1), out group);
+            return child.TryGetGroup(keyParts.Skip(1), out group);*/
         }
 
         /// <summary>

--- a/Toml/Group.cs
+++ b/Toml/Group.cs
@@ -204,14 +204,6 @@ namespace Toml
             }
             group = null;
             return false;
-            /*Group child = _children[keyParts.First()] as Group;
-            if (child == null)
-            {
-                group = null;
-                return false;
-            }
-
-            return child.TryGetGroup(keyParts.Skip(1), out group);*/
         }
 
         /// <summary>


### PR DESCRIPTION
解决TryGetGroup不存在的key时抛出异常（如果抛出了异常有违Try的意义）的问题。